### PR TITLE
Support for bitcoinz urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bitcore-wallet-client-btcz",
   "description": "Client for bitcore-wallet-service-btcz",
   "author": "BitcoinZ Community",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "keywords": [
     "bitcoin",
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "bip38": "^1.3.0",
-    "bitcore-lib-btcz": "git+https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#support-for-bitcoinz-url",
+    "bitcore-lib-btcz": "git+https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#v1.0.2",
     "bitcore-mnemonic": "^1.2.2",
     "bitcore-payment-protocol": "^1.2.2",
     "json-stable-stringify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "bip38": "^1.3.0",
-    "bitcore-lib-btcz": "git+https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#v1.0.1",
+    "bitcore-lib-btcz": "git+https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#support-for-bitcoinz-url",
     "bitcore-mnemonic": "^1.2.2",
     "bitcore-payment-protocol": "^1.2.2",
     "json-stable-stringify": "^1.0.0",


### PR DESCRIPTION
Updated the packages.json to include updated bitcore-lib-btcz with
support for bitcoinz urls.

References: bitcoinz-wallets/bitcoinz-copay-wallet#21